### PR TITLE
Add Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ Komut çalıştığında indirme onayı istenir. `y` diyerek indirilen dosyayı 
 ```bash
 python -m unittest discover -s tests
 ```
+
+## Web Arayuzu
+
+Basit bir web formu ile dosya indirmek icin:
+
+```bash
+python -m taktak.webapp
+```
+
+Uygulama calistiginda tarayicinizdan `http://localhost:5000` adresini ziyaret
+ederek URL ve cikti klasorunu belirtebilirsiniz.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.0
+Flask>=2.0

--- a/taktak/webapp.py
+++ b/taktak/webapp.py
@@ -1,0 +1,41 @@
+from flask import Flask, request, render_template_string
+import pathlib
+
+from .downloader import download_file, is_valid_url
+
+app = Flask(__name__)
+
+HTML_FORM = '''
+<!doctype html>
+<title>TakTak Downloader</title>
+<h1>Download a URL</h1>
+<form method="post">
+    URL: <input type="text" name="url" required><br>
+    Output Directory: <input type="text" name="output" value="." required><br>
+    <input type="submit" value="Download">
+</form>
+{% if message %}
+<p>{{ message }}</p>
+{% endif %}
+'''
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    message = ''
+    if request.method == 'POST':
+        url = request.form.get('url', '')
+        output = request.form.get('output', '.')
+        if not is_valid_url(url):
+            message = 'Invalid URL'
+        else:
+            try:
+                path = download_file(url, pathlib.Path(output))
+                message = f'Saved to {path}'
+            except Exception as exc:
+                message = f'Error: {exc}'
+    return render_template_string(HTML_FORM, message=message)
+
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- create `webapp.py` for a Flask-based web frontend
- update requirements with Flask
- document the new web interface in README

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687e957b46508327bcca0701b57b4c6d