### PR TITLE
Add YouTube download support with new videos output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ pip install -r requirements.txt
 python -m taktak <URL> [-o cikti_klasoru]
 ```
 
+Varsayilan cikti klasoru `videos` dizinidir. `-o` parametresi ile baska bir klasor
+belirtebilirsiniz.
+
 Örnek:
 
 ```bash
@@ -41,3 +44,9 @@ python -m taktak.webapp
 
 Uygulama calistiginda tarayicinizdan `http://localhost:5000` adresini ziyaret
 ederek URL ve cikti klasorunu belirtebilirsiniz.
+
+## YouTube Videolari
+
+TakTak artik YouTube baglantilarini da indirebilir. Bir YouTube URL'i verdiginizde
+en yuksek cozumlu MP4 akisi otomatik olarak secilir ve `videos` klasorune
+kaydedilir.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.0
 Flask>=2.0
+pytube>=15.0.0

--- a/taktak/cli.py
+++ b/taktak/cli.py
@@ -6,7 +6,12 @@ from .downloader import download_file, is_valid_url
 def main():
     parser = argparse.ArgumentParser(description='TakTak URL downloader')
     parser.add_argument('url', help='URL to download')
-    parser.add_argument('-o', '--output', default='.', help='Output directory')
+    parser.add_argument(
+        '-o',
+        '--output',
+        default='videos',
+        help='Output directory (default: videos)',
+    )
     args = parser.parse_args()
 
     url = args.url

--- a/taktak/downloader.py
+++ b/taktak/downloader.py
@@ -5,6 +5,23 @@ import urllib.parse
 from typing import Optional
 
 import requests
+from pytube import YouTube
+
+YOUTUBE_DOMAINS = {
+    'youtube.com',
+    'www.youtube.com',
+    'm.youtube.com',
+    'youtu.be',
+}
+
+
+def is_youtube_url(url: str) -> bool:
+    """Return True if the URL points to YouTube."""
+    try:
+        parsed = urllib.parse.urlparse(url)
+        return parsed.netloc in YOUTUBE_DOMAINS
+    except Exception:
+        return False
 
 
 def is_valid_url(url: str) -> bool:
@@ -38,13 +55,30 @@ def get_filename_from_url(url: str, response: Optional[requests.Response] = None
 def download_file(url: str, dest_dir: pathlib.Path) -> pathlib.Path:
     if not is_valid_url(url):
         raise ValueError('Invalid URL provided')
+
     dest_dir = pathlib.Path(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
+
+    if is_youtube_url(url):
+        yt = YouTube(url)
+        stream = (
+            yt.streams.filter(progressive=True, file_extension="mp4")
+            .order_by("resolution")
+            .desc()
+            .first()
+        )
+        if stream is None:
+            raise ValueError("No downloadable video stream found")
+        filename = stream.default_filename
+        filepath = dest_dir / filename
+        stream.download(output_path=dest_dir, filename=filename)
+        return filepath
+
     with requests.get(url, stream=True) as resp:
         resp.raise_for_status()
         filename = get_filename_from_url(url, resp)
         filepath = dest_dir / filename
-        with open(filepath, 'wb') as f:
+        with open(filepath, "wb") as f:
             for chunk in resp.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)

--- a/taktak/webapp.py
+++ b/taktak/webapp.py
@@ -11,7 +11,7 @@ HTML_FORM = '''
 <h1>Download a URL</h1>
 <form method="post">
     URL: <input type="text" name="url" required><br>
-    Output Directory: <input type="text" name="output" value="." required><br>
+    Output Directory: <input type="text" name="output" value="videos" required><br>
     <input type="submit" value="Download">
 </form>
 {% if message %}
@@ -25,7 +25,7 @@ def index():
     message = ''
     if request.method == 'POST':
         url = request.form.get('url', '')
-        output = request.form.get('output', '.')
+        output = request.form.get('output', 'videos')
         if not is_valid_url(url):
             message = 'Invalid URL'
         else:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,15 +1,31 @@
 import unittest
-from taktak.downloader import get_filename_from_url
+from unittest import mock
+import pathlib
+from taktak import downloader
 
 
 class TestDownloader(unittest.TestCase):
     def test_get_filename_from_url(self):
         url = 'https://example.com/path/to/file.txt'
-        self.assertEqual(get_filename_from_url(url), 'file.txt')
+        self.assertEqual(downloader.get_filename_from_url(url), 'file.txt')
 
     def test_get_filename_when_no_name(self):
         url = 'https://example.com/'
-        self.assertEqual(get_filename_from_url(url), 'downloaded.file')
+        self.assertEqual(downloader.get_filename_from_url(url), 'downloaded.file')
+
+    def test_is_youtube_url(self):
+        self.assertTrue(downloader.is_youtube_url('https://www.youtube.com/watch?v=dQw4w9WgXcQ'))
+        self.assertFalse(downloader.is_youtube_url('https://example.com/video'))
+
+    def test_youtube_download_uses_pytube(self):
+        fake_stream = mock.Mock()
+        fake_stream.default_filename = 'vid.mp4'
+        fake_stream.download.return_value = None
+        fake_yt = mock.Mock(return_value=mock.Mock(streams=mock.Mock(filter=mock.Mock(return_value=mock.Mock(order_by=mock.Mock(return_value=mock.Mock(desc=mock.Mock(return_value=mock.Mock(first=mock.Mock(return_value=fake_stream))))))))))
+        with mock.patch('taktak.downloader.YouTube', fake_yt):
+            path = downloader.download_file('https://youtu.be/test', pathlib.Path('tmp'))
+        self.assertEqual(path.name, 'vid.mp4')
+        fake_stream.download.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add pytube dependency
- detect YouTube URLs and download with pytube
- change default output folder to `videos` in CLI and webapp
- update README with defaults and YouTube instructions
- test YouTube detection and downloading behavior

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e9df38e748327b783fe7c498703af